### PR TITLE
Add static file support

### DIFF
--- a/examples/public/static.html
+++ b/examples/public/static.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>A static page</title>
+  </head>
+  <body>
+    <h1>A static page</h1>
+    <p>Yup.</p>
+  </body>
+</html>


### PR DESCRIPTION
By having a public directory, those files will be served statically,
automatically.

An example is placed in the examples directory; this means that if you
want to try an example with `cargo run --example`, you have to be in the
examples directory rather than the root to see the static files.