### PR TITLE
An example of a closure handler.

### DIFF
--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -1,18 +1,15 @@
 extern crate simple_server;
 
-use simple_server::{Server, Request, Response};
-use simple_server::response::Builder as ResponseBuilder;
+use simple_server::Server;
 
 fn main() {
+    let server = Server::new(|request, mut response| {
+        println!("Request received. {} {}", request.method(), request.uri());
+        response.body("Hello Rust!".as_bytes()).unwrap()
+    });
+
     let host = "127.0.0.1";
     let port = "7878";
 
-    fn handler(request: Request<&[u8]>, mut response_builder: ResponseBuilder) -> Response<&[u8]> {
-        println!("Request received. {} {}", request.method(), request.uri());
-        response_builder.body("Hello Rust!".as_bytes()).unwrap()
-    };
-
-    let server = Server::new(handler);
-
-    server.listen(host, port)
+    server.listen(host, port);
 }


### PR DESCRIPTION
Fixes #4 

In today's Rust, closures with no environment decay to `fn`s, so this Just Works.

The question is, do we want to support closures that capture stuff? That'd look like this:

```rust
    let s = "Rust";

    let server = Server::new(|request, mut response_builder| {
        println!("Request received. {} {}", request.method(), request.uri());
        response_builder.body(format!("Hello {}!", s).as_bytes()).unwrap()
    });
```

Which currently gives

```text
error[E0308]: mismatched types
  --> examples\closure_handler.rs:17:30
   |
17 |       let server = Server::new(|request, mut response_builder| {
   |  ______________________________^
18 | |         println!("Request received. {} {}", request.method(), request.uri());
19 | |         response_builder.body(format!("Hello {}!", s).as_bytes()).unwrap()
20 | |     });
   | |_____^ expected fn pointer, found closure
   |
   = note: expected type `fn(simple_server::Request<&[u8]>, simple_server::response::Builder) -> simple_server::Response<&[u8]>`
              found type `[closure@examples\closure_handler.rs:17:30: 20:6 s:_]`

error: aborting due to previous error
```

as an error.