### PR TITLE
Introduce fallable handlers

### DIFF
--- a/examples/routes.rs
+++ b/examples/routes.rs
@@ -1,28 +1,24 @@
 extern crate simple_server;
 
-use simple_server::{Server, Request, Response, StatusCode};
-use simple_server::response::Builder as ResponseBuilder;
-use simple_server::Method;
+use simple_server::{Server, Method, StatusCode};
 
 fn main() {
     let host = "127.0.0.1";
     let port = "7878";
 
-    fn handler(request: Request<&[u8]>, mut response_builder: ResponseBuilder) -> Response<&[u8]> {
+    let server = Server::new(|request, mut response| {
         println!("Request received. {} {}", request.method(), request.uri());
 
         match (request.method(), request.uri().path()) {
             (&Method::GET, "/hello") => {
-                response_builder.body("<h1>Hi!</h1><p>Hello Rust!</p>".as_bytes()).unwrap()
+                Ok(response.body("<h1>Hi!</h1><p>Hello Rust!</p>".as_bytes())?)
             }
             (_, _) => {
-                response_builder.status(StatusCode::NOT_FOUND);
-                response_builder.body("<h1>404</h1><p>Not found!<p>".as_bytes()).unwrap()
+                response.status(StatusCode::NOT_FOUND);
+                Ok(response.body("<h1>404</h1><p>Not found!<p>".as_bytes())?)
             }
         }
-    };
+    });
 
-    let server = Server::new(handler);
-
-    server.listen(host, port)
+    server.listen(host, port);
 }

--- a/examples/simple-server.rs
+++ b/examples/simple-server.rs
@@ -3,13 +3,13 @@ extern crate simple_server;
 use simple_server::Server;
 
 fn main() {
-    let server = Server::new(|request, mut response| {
-        println!("Request received. {} {}", request.method(), request.uri());
-        response.body("Hello Rust!".as_bytes()).unwrap()
-    });
-
     let host = "127.0.0.1";
     let port = "7878";
+
+    let server = Server::new(|request, mut response| {
+        println!("Request received. {} {}", request.method(), request.uri());
+        Ok(response.body("Hello Rust!".as_bytes())?)
+    });
 
     server.listen(host, port);
 }

--- a/tests/simple-server.rs
+++ b/tests/simple-server.rs
@@ -1,14 +1,21 @@
 extern crate simple_server;
-extern crate http;
 
-use simple_server::{Server, Request, Response};
-use http::response::Builder as ResponseBuilder;
+use simple_server::Server;
 
 #[test]
-fn test_new() {
-    fn handler(_request: Request<&[u8]>, mut response_builder: ResponseBuilder) -> Response<&[u8]> {
-        response_builder.body("Hello Rust!".as_bytes()).unwrap()
-    };
+fn test_server_new() {
+    Server::new(|_request, mut response| {
+        Ok(response.body("Hello Rust!".as_bytes())?)
+    });
+}
 
-    Server::new(handler);
+#[test]
+fn test_error_fallback() {
+    Server::new(|_request, mut response| {
+        // set an invalid header
+        response.header("Foo", "Bar\r\n");
+
+        // this will then fail
+        response.body("".as_bytes())
+    });
 }


### PR DESCRIPTION
If your request fails, we return a 500 internal server error.

This is useful so that things built on top can propogate errors if
they don't care about handling them specifically, making the server
overall more robust.

This should help with https://github.com/steveklabnik/simple-server/issues/21