### PR TITLE
fix(docs): remove internal details

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,10 +22,6 @@ mod error;
 use error::Error;
 
 /// Represents a server.
-///
-/// | Member    | Type                                       | Notes                                                               |
-/// |-----------|--------------------------------------------|---------------------------------------------------------------------|
-/// | `handler` | `fn(Request<&[u8]>, &mut Response<&[u8]>)` | This function uses Types that are re-exported from the `http` crate |
 pub struct Server {
     handler: fn(Request<&[u8]>, ResponseBuilder) -> Result<Response<&[u8]>, Error>,
 }


### PR DESCRIPTION
This isn't public, and so documenting it doesn't make sense.

Furthermore, the types give us all of this information, so it's
redundant.

Finally, it's longer than the line limit, and so if we were to keep it,
would need to be at least wrapped.