### PR TITLE
feat(api): Shrink our public interface slightly

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@ extern crate http;
 extern crate httparse;
 extern crate scoped_threadpool;
 
-pub use http::{response, status, Request, Response};
-pub use http::status::StatusCode;
+pub use http::{response, Request, Response};
+pub use http::status::{InvalidStatusCode, StatusCode};
 pub use http::method::Method;
 use http::response::Builder as ResponseBuilder;
 


### PR DESCRIPTION
We were `pub use`ing the whole `status` module. Right now, it only has
two things in it, `StatusCode` and `InvalidStatusCode`. We re-export
`StatusCode` already, as such, I've re-exported `InvalidStatusCode`
too, and privately imported `status`. This insulates us from new
things being added to that module by HTTP.

An alternative might be to *only* `pub use` the `status` module, but given that we have only so few things, and they're already all at the root, this feels better to me.