### PR TITLE
Allow graceful termination of TCPConnection.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,10 @@ impl Server {
     fn handle_connection(&self, mut stream: TcpStream) -> Result<(), Error> {
         let mut buffer = [0; 512];
 
-        stream.read(&mut buffer)?;
+        if stream.read(&mut buffer)? == 0 {
+            // Connection closed
+            return Ok(());
+        }
 
         let request = parse_request(&buffer)?;
         let mut response_builder = Response::builder();


### PR DESCRIPTION
Fixes #65

According to [rust docs](https://doc.rust-lang.org/std/io/trait.Read.html#tymethod.read), `read` on a socket returning 0 bytes is a valid way to indicate the connection has been closed.