### PR TITLE
feat: print listening url

### DIFF
--- a/examples/routes.rs
+++ b/examples/routes.rs
@@ -24,5 +24,6 @@ fn main() {
         }
     });
 
+    println!("Listening on http://{}:{}/", host, port);
     server.listen(host, port);
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -17,5 +17,6 @@ fn main() {
         Ok(response.body("Hello Rust!".as_bytes())?)
     });
 
+    println!("Listening on http://{}:{}/", host, port);
     server.listen(host, port);
 }


### PR DESCRIPTION
Just a little helper if your terminal allows you to click on listening URL. Here's what it looks like:

```
$ cargo run --example routes
    Finished dev [unoptimized + debuginfo] target(s) in 0.0 secs
     Running `target/debug/examples/routes`
Listening on http://127.0.0.1:7878/
```