### PR TITLE
change unwrap to expect

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,7 +194,7 @@ fn write_response(response: Response<&[u8]>, mut stream: TcpStream) -> Result<()
         format!(
         "HTTP/1.1 {} {}\r\n\r\n",
         response.status().as_str(),
-        response.status().canonical_reason().unwrap(),
+        response.status().canonical_reason().expect("Unsupported HTTP Status"),
     );
     stream.write(text.as_bytes())?;
 


### PR DESCRIPTION
Don't `unwrap` an `Option`, even when you think it can't fail, since an unwrapped `None` provides no useful information.

This one **will** fail when the status code is set to one without a canonical reason, but the `Error` enum has no variants for local errors (which is what this would need to be).