### PR TITLE
Mitigate traversal attacks using //

### DIFF
--- a/examples/headers.rs
+++ b/examples/headers.rs
@@ -5,8 +5,8 @@ extern crate log;
 extern crate http;
 extern crate simple_server;
 
-use simple_server::Server;
 use http::header;
+use simple_server::Server;
 
 fn main() {
     env_logger::init().unwrap();

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
-use std;
 use http;
 use httparse;
+use std;
 
 /// Various errors that may happen while handling requests.
 #[derive(Debug)]
@@ -15,7 +15,8 @@ pub enum Error {
     InvalidUri(http::uri::InvalidUri),
     /// The request timed out.
     Timeout,
-    #[doc(hidden)] RequestIncomplete,
+    #[doc(hidden)]
+    RequestIncomplete,
     /// The request's size (headers + body) exceeded the application's limit.
     RequestTooLarge,
     /// The connection was closed while reading the request.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,10 +33,10 @@ extern crate scoped_threadpool;
 extern crate time;
 
 pub use http::Request;
-pub use http::response::{Builder, Parts, Response};
-pub use http::status::{InvalidStatusCode, StatusCode};
 pub use http::method::Method;
 pub use http::response::Builder as ResponseBuilder;
+pub use http::response::{Builder, Parts, Response};
+pub use http::status::{InvalidStatusCode, StatusCode};
 
 use scoped_threadpool::Pool;
 
@@ -51,8 +51,8 @@ use std::time::Duration;
 use std::borrow::Borrow;
 
 mod error;
-mod request;
 mod parsing;
+mod request;
 
 pub use error::Error;
 
@@ -368,11 +368,9 @@ impl Server {
             let fs_path = PathBuf::from(&fs_path[1..]);
 
             // ... you trying to do something bad?
-            let traversal_attempt = fs_path.components().any(|component| {
-                match component {
-                    std::path::Component::Normal(_) => false,
-                    _ => true,
-                }
+            let traversal_attempt = fs_path.components().any(|component| match component {
+                std::path::Component::Normal(_) => false,
+                _ => true,
             });
 
             if traversal_attempt {
@@ -387,7 +385,7 @@ impl Server {
                 return Ok(());
             }
 
-            let fs_path = self.static_directory.join(fs_path);
+            let fs_path = static_directory.join(fs_path);
 
             if Path::new(&fs_path).is_file() {
                 let mut f = File::open(&fs_path)?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,7 @@
+use super::Request;
+use error::Error;
 use std::io::{self, Read};
 use std::time::{Duration, Instant};
-use error::Error;
-use super::Request;
 
 use parsing;
 


### PR DESCRIPTION
Attack described in https://github.com/steveklabnik/simple-server/issues/54#issuecomment-375720674.

This is much simpler than the first two ideas I had :p  Instead of checking for traversal attacks by looking for the presence of the strings `"./"` or `"../"`, it does it by putting the URI (sans leading `/`) into a PathBuf and checking if any of its components aren't [normal](https://doc.rust-lang.org/std/path/enum.Component.html#variant.Normal).

edit: amended several times to get the formatting right haha.