### PR TITLE
Automatically add Content-Length/Date/Connection headers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ httparse = "1.2.3"
 log = "0.3"
 num_cpus = "1"
 scoped_threadpool = "0.1.7"
+time = "0.1"
 
 [dev-dependencies]
 env_logger = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,6 +401,9 @@ fn write_response<T: Borrow<[u8]>, S: Write>(
         let date = time::strftime("%a, %d %b %Y %H:%M:%S GMT", &time::now_utc()).unwrap();
         write!(text, "date: {}\r\n", date).unwrap();
     }
+    if !parts.headers.contains_key(http::header::CONNECTION) {
+        write!(text, "connection: close\r\n").unwrap();
+    }
     if !parts.headers.contains_key(http::header::CONTENT_LENGTH) {
         write!(text, "content-length: {}\r\n", body.len()).unwrap();
     }
@@ -425,6 +428,7 @@ fn test_write_response() {
     let mut output = vec![];
     let _ = write_response(builder.body("Hello rust".as_bytes()).unwrap(), &mut output).unwrap();
     let expected = b"HTTP/1.1 200 OK\r\n\
+        connection: close\r\n\
         content-length: 10\r\n\
         date: Thu, 01 Jan 1970 00:00:00 GMT\r\n\
         content-type: text/plain\r\n\
@@ -444,6 +448,7 @@ fn test_write_response_no_headers() {
     let mut output = vec![];
     let _ = write_response(builder.body("Hello rust".as_bytes()).unwrap(), &mut output).unwrap();
     let expected = b"HTTP/1.1 200 OK\r\n\
+        connection: close\r\n\
         content-length: 10\r\n\
         date: Thu, 01 Jan 1970 00:00:00 GMT\r\n\
         \r\n\


### PR DESCRIPTION
This adds the headers mentioned in #86.

They will only be written if the user callback didn't already assign values to these headers (you can see that working in the tests where I put the epoch into the date field; otherwise the date would depend on when the test ran making them more complicated). This is a change from the current behavior in the case of `Content-Length`, because you can now lie and give the wrong length if you like. But I think this is a simple way to allow the user to control their values/order if they really want to.

Writing the date was done by adding a dependency on the `time` crate.

A response from the `server.rs` example now looks like

```
< HTTP/1.1 200 OK
< date: Sun, 25 Mar 2018 03:45:27 GMT
< connection: close
< content-length: 11
< 
< Hello Rust!
````