### PR TITLE
Remove extraneous unwrap()

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,7 +7,7 @@ extern crate simple_server;
 use simple_server::Server;
 
 fn main() {
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let host = "127.0.0.1";
     let port = "7878";


### PR DESCRIPTION
`env_logger::init()` panics rather than returning an error, so `unwrap()` causes a compile error here.