### PR TITLE
fix crash when client connection is aborted

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -343,6 +343,9 @@ impl Server {
             Err(Error::ConnectionClosed) | Err(Error::Timeout) | Err(Error::HttpParse(_)) => {
                 return Ok(())
             }
+            Err(Error::Io(ref io_error)) if io_error.kind() == std::io::ErrorKind::BrokenPipe => {
+                return Ok(())
+            }
 
             Err(Error::RequestTooLarge) => {
                 let resp = Response::builder()


### PR DESCRIPTION
if i cancel a request to a simple-server running on localhost, by closing a browser tab or holding F5, sometimes it crashes with a 'broken pipe' error. it seems benign and expected that that would sometimes happen, so this PR ignores requests that error out like that, instead of crashing the process.