### PR TITLE
Newer dependencies versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,12 @@ categories = ["web-programming"]
 travis-ci = { repository = "steveklabnik/simple-server" }
 
 [dependencies]
-http = "0.1.0"
-httparse = "1.2.3"
-log = "0.3"
+http = "0"
+httparse = "1"
+log = "0"
 num_cpus = "1"
-scoped_threadpool = "0.1.7"
+scoped_threadpool = "0"
 time = "0.1"
 
 [dev-dependencies]
-env_logger = "0.3"
+env_logger = "0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,7 +59,7 @@ pub use error::Error;
 pub type ResponseResult = Result<Response<Vec<u8>>, Error>;
 
 pub type Handler =
-    Box<Fn(Request<Vec<u8>>, ResponseBuilder) -> ResponseResult + 'static + Send + Sync>;
+    Box<dyn Fn(Request<Vec<u8>>, ResponseBuilder) -> ResponseResult + 'static + Send + Sync>;
 
 /// A web server.
 ///
@@ -375,7 +375,7 @@ impl Server {
 
             if traversal_attempt {
                 // GET OUT
-                response_builder.status(StatusCode::NOT_FOUND);
+                response_builder = response_builder.status(StatusCode::NOT_FOUND);
 
                 let response = response_builder
                     .body("<h1>404</h1><p>Not found!<p>".as_bytes())
@@ -404,10 +404,8 @@ impl Server {
         match (self.handler)(request, response_builder) {
             Ok(response) => Ok(write_response(response, stream)?),
             Err(_) => {
-                let mut response_builder = Response::builder();
-                response_builder.status(StatusCode::INTERNAL_SERVER_ERROR);
-
-                let response = response_builder
+                let response = Response::builder()
+                    .status(StatusCode::INTERNAL_SERVER_ERROR)
                     .body("<h1>500</h1><p>Internal Server Error!<p>".as_bytes())
                     .unwrap();
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -29,7 +29,7 @@ pub fn read<S: Read>(stream: &mut S, timeout: Option<Duration>) -> Result<Reques
                 match parsing::try_parse_request(mem::replace(&mut buffer, vec![]))? {
                     parsing::ParseResult::Complete(r) => break r,
                     parsing::ParseResult::Partial(b) => {
-                        mem::replace(&mut buffer, b);
+                        let _old = mem::replace(&mut buffer, b);
                         continue;
                     }
                 }
@@ -57,10 +57,10 @@ pub fn read<S: Read>(stream: &mut S, timeout: Option<Duration>) -> Result<Reques
 fn build_request(mut req: parsing::Request) -> Result<Request<Vec<u8>>, Error> {
     let mut http_req = Request::builder();
 
-    http_req.method(req.method());
+    http_req = http_req.method(req.method());
 
     for header in req.headers() {
-        http_req.header(header.name, header.value);
+        http_req = http_req.header(header.name, header.value);
     }
 
     let mut request = http_req.body(req.split_body())?;


### PR DESCRIPTION
I respectfully request you consider my PR: It allows the project to use newer versions of its dependencies. In particular, the HTTP dependency is quite old, and was causing clashes for one of my projects, where simple-server's http struct was incompatible with the http used by another dependency. This also resolves some warnings with the newer compiler. Thanks!